### PR TITLE
Update from FTP to SFTP

### DIFF
--- a/request_for_comment/draft/rfc_002_how_to_make_data_fair.md
+++ b/request_for_comment/draft/rfc_002_how_to_make_data_fair.md
@@ -228,7 +228,7 @@ The FAIR principles are equally applicable to all data regardless of how open th
 
 - Implement a DOI retrieval option in the local interface.
 
-- Implement a DOI retrieval option in the API, FTP, and other programmatic interface(s).
+- Implement a DOI retrieval option in the API, SFTP, and other programmatic interface(s).
 
 ### A1.1 the protocol is open, free, and universally implementable
 


### PR DESCRIPTION
Per most NASA IT Security directives nowadays, there is no more FTP access to NASA data, only SFTP. I may be wrong, but worth reviewing.